### PR TITLE
Fix: 지도 필터 기능 오류 수정

### DIFF
--- a/src/components/common/KaKaoMap/KaKaoMap.jsx
+++ b/src/components/common/KaKaoMap/KaKaoMap.jsx
@@ -1,7 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { Circle, Map, MapMarker, useKakaoLoader } from 'react-kakao-maps-sdk';
 import { useDispatch, useSelector } from 'react-redux';
-import { changeCenter, mapCafeList, setCafeData, setMarkerOpen } from '../../../redux/slices/mapSlice';
+import {
+  ResetPositionToDefault,
+  changeCenter,
+  mapCafeList,
+  setCafeData,
+  setCurrentPositionAddress,
+  setMarkerOpen
+} from '../../../redux/slices/mapSlice';
 import { Address, CloseBtn, MapContainer, MarkerDiv, Phone, RoadAdd, Title } from './KaKaoMap.style';
 
 function KaKaoMap(data) {
@@ -20,6 +27,7 @@ function KaKaoMap(data) {
 
   //원 범위
   useEffect(() => {
+    dispatch(ResetPositionToDefault());
     switch (level) {
       case 1:
         setLength(75);
@@ -135,6 +143,7 @@ function KaKaoMap(data) {
     const callback = function (result, status) {
       if (status === window.kakao.maps.services.Status.OK) {
         setAddress(result[0].address.address_name);
+        dispatch(setCurrentPositionAddress(result[0].address.address_name));
       } else if (status === window.kakao.maps.services.Status.ZERO_RESULT) {
         console.log('결과가 존재하지 않습니다.');
         return;

--- a/src/redux/slices/mapSlice.js
+++ b/src/redux/slices/mapSlice.js
@@ -5,8 +5,8 @@ const mapSlice = createSlice({
   initialState: {
     level: 3,
     position: {
-      lat: 33.450701,
-      lng: 126.570667
+      lat: 37.49799993466257,
+      lng: 127.0275987857109
     },
     searchText: '',
     cafeList: [],
@@ -37,6 +37,15 @@ const mapSlice = createSlice({
     },
     ViewAllRegion: (state) => {
       state.viewAll = true;
+    },
+    setCurrentPositionAddress: (state, action) => {
+      state.address = action.payload;
+    },
+    ResetPositionToDefault: (state) => {
+      state.position = {
+        lat: 37.49799993466257,
+        lng: 127.0275987857109
+      };
     }
   }
 });
@@ -48,7 +57,9 @@ export const {
   setCafeData,
   ViewSpecificRegionRange,
   ViewAllRegion,
-  setMarkerOpen
+  setMarkerOpen,
+  setCurrentPositionAddress,
+  ResetPositionToDefault
 } = mapSlice.actions;
 
 export default mapSlice.reducer;


### PR DESCRIPTION
## 🔎 작업 내용

- mapSlice 및 KakaoMap 컴포넌트 작업 통해서 메인페이지 내 지역(지도) 필터 걸 시 어디를 중심으로 검색중인지가 잘 표시되도록 고쳐놨습니다

  <br/>

## 이미지 첨부

![image](https://github.com/parkchowon/cafe-pin/assets/39695585/0226d7c7-13ff-4954-a105-3690af568f11)

<br/>

## 주의 사항

- 없어용

<br/>
